### PR TITLE
Setup logger with fern

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,4 +35,4 @@ jobs:
           name: Test on nightly
           command: "rustup run nightly cargo test-xunit"
       - store_test_results:
-          path: "test-results.xml"
+          path: test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
           name: Update all versions
           command: "rustup update beta && rustup update stable"
       - run:
+          name: Install test-xunit
+          command: "cargo install --git https://github.com/evernym/cargo-test-xunit"
+      - run:
           name: Show toolchain versions
           command: "rustup show"
       - run:
@@ -18,16 +21,18 @@ jobs:
           command: "rustup run stable cargo build"
       - run:
           name: Test on stable
-          command: "rustup run stable cargo test"
+          command: "rustup run stable cargo test-xunit"
       - run:
           name: Build on beta
           command: "rustup run beta cargo build"
       - run:
           name: Test on beta
-          command: "rustup run beta cargo test"
+          command: "rustup run beta cargo test-xunit"
       - run:
           name: Build on nightly
           command: "rustup run nightly cargo build"
       - run:
           name: Test on nightly
-          command: "rustup run nightly cargo test"
+          command: "rustup run nightly cargo test-xunit"
+      - store_test_results:
+          path: "test-results.xml"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,6 @@ jobs:
           name: Update all versions
           command: "rustup update beta && rustup update stable"
       - run:
-          name: Install test-xunit
-          command: "cargo install --git https://github.com/evernym/cargo-test-xunit"
-      - run:
           name: Show toolchain versions
           command: "rustup show"
       - run:
@@ -21,18 +18,18 @@ jobs:
           command: "rustup run stable cargo build"
       - run:
           name: Test on stable
-          command: "rustup run stable cargo test-xunit"
+          command: "rustup run stable cargo test"
       - run:
           name: Build on beta
           command: "rustup run beta cargo build"
       - run:
           name: Test on beta
-          command: "rustup run beta cargo test-xunit"
+          command: "rustup run beta cargo test"
       - run:
           name: Build on nightly
           command: "rustup run nightly cargo build"
       - run:
           name: Test on nightly
-          command: "rustup run nightly cargo test-xunit && echo $pwd && ls"
+          command: "rustup run nightly cargo test-xunit"
       - store_test_results:
           path: ~/sonos/test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,9 @@ jobs:
           name: Update all versions
           command: "rustup update beta && rustup update stable"
       - run:
+          name: Install test-xunit
+          command: "cargo install --git https://github.com/evernym/cargo-test-xunit"
+      - run:
           name: Show toolchain versions
           command: "rustup show"
       - run:
@@ -18,13 +21,13 @@ jobs:
           command: "rustup run stable cargo build"
       - run:
           name: Test on stable
-          command: "rustup run stable cargo test"
+          command: "rustup run stable cargo test-xunit"
       - run:
           name: Build on beta
           command: "rustup run beta cargo build"
       - run:
           name: Test on beta
-          command: "rustup run beta cargo test"
+          command: "rustup run beta cargo test-xunit"
       - run:
           name: Build on nightly
           command: "rustup run nightly cargo build"
@@ -32,4 +35,4 @@ jobs:
           name: Test on nightly
           command: "rustup run nightly cargo test-xunit"
       - store_test_results:
-          path: ~/sonos/test-results.xml
+          path: test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,3 +13,21 @@ jobs:
       - run:
           name: Show toolchain versions
           command: "rustup show"
+      - run:
+          name: Build on stable
+          command: "rustup run stable cargo build"
+      - run:
+          name: Test on stable
+          command: "rustup run stable cargo test"
+      - run:
+          name: Build on beta
+          command: "rustup run beta cargo build"
+      - run:
+          name: Test on beta
+          command: "rustup run beta cargo test"
+      - run:
+          name: Build on nightly
+          command: "rustup run nightly cargo build"
+      - run:
+          name: Test on nightly
+          command: "rustup run nightly cargo test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,6 +33,6 @@ jobs:
           command: "rustup run nightly cargo build"
       - run:
           name: Test on nightly
-          command: "rustup run nightly cargo test-xunit"
+          command: "rustup run nightly cargo test-xunit && echo $pwd && ls"
       - store_test_results:
           path: ~/sonos/test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,4 +35,4 @@ jobs:
           name: Test on nightly
           command: "rustup run nightly cargo test-xunit"
       - store_test_results:
-          path: test-results.xml
+          path: ~/sonos/test-results.xml

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ jobs:
       - checkout
       - run:
           name: Update all versions
-          command: "rustup update nightly && rustup update beta && rustup update stable"
+          command: "rustup update beta && rustup update stable"
       - run:
           name: Show toolchain versions
           command: "rustup show"

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # IDE
 *.iml
 .idea
+
+# Tests
+*.xml

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,8 @@
 name = "sonos"
 version = "0.1.0"
 dependencies = [
+ "fern 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "sonos_discovery 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -24,8 +26,21 @@ version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "fern"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "libc"
 version = "0.2.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "log"
+version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -146,7 +161,9 @@ dependencies = [
 "checksum bitflags 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "aad18937a628ec6abcd26d1489012cc0e18c21798210f491af69ded9b881106d"
 "checksum conv 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "78ff10625fd0ac447827aa30ea8b861fead473bb60aeb73af6c1c58caf0d1299"
 "checksum custom_derive 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "ef8ae57c4978a2acd8b869ce6b9ca1dfe817bff704c220209fdef2c0b75a01b9"
+"checksum fern 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "c72a8154b857a2cb15c2147f51293d4a8c243d0d157e2da2acd7b96f5c24a48a"
 "checksum libc 0.2.30 (registry+https://github.com/rust-lang/crates.io-index)" = "2370ca07ec338939e356443dac2296f581453c35fe1e3a3ed06023c49435f915"
+"checksum log 0.3.8 (registry+https://github.com/rust-lang/crates.io-index)" = "880f77541efa6e5cc74e76910c9884d9859683118839d6a1dc3b11e63512565b"
 "checksum magenta 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4bf0336886480e671965f794bc9b6fce88503563013d1bfb7a502c81fe3ac527"
 "checksum magenta-sys 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "40d014c7011ac470ae28e2f76a02bfea4a8480f73e701353b49ad7a8d75f4699"
 "checksum num 0.1.40 (registry+https://github.com/rust-lang/crates.io-index)" = "a311b77ebdc5dd4cf6449d81e4135d9f0e3b153839ac90e648a8ef538f923525"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ authors = ["chabare <chabare95@gmail.com>"]
 
 [dependencies]
 sonos_discovery = "0.0.1"
+log = "*"
+fern = "*"

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,19 +23,11 @@ fn setup_logging(level: log::LogLevelFilter, file: Option<std::path::PathBuf>) -
 
 
     let stderr_dispatcher = fern::Dispatch::new().filter(|data| {
-        match data.level().cmp(&log::LogLevelFilter::Warn.to_log_level().unwrap()) {
-            std::cmp::Ordering::Less => true,
-            std::cmp::Ordering::Equal => true,
-            _ => false
-        }
+        data.level() <= log::LogLevelFilter::Warn
     }).chain(std::io::stderr());
 
     let stdout_dispatcher = fern::Dispatch::new().filter(|data| {
-        match data.level().cmp(&log::LogLevelFilter::Warn.to_log_level().unwrap()) {
-            std::cmp::Ordering::Less => false,
-            std::cmp::Ordering::Equal => false,
-            _ => true
-        }
+        data.level() > log::LogLevelFilter::Warn
     });
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -43,3 +43,23 @@ fn setup_logging(level: log::LogLevelFilter, file: Option<std::path::PathBuf>) -
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use log;
+    use super::setup_logging;
+
+    #[test]
+    fn setup() {
+        assert!(match setup_logging(log::LogLevelFilter::Debug, None) {
+            Ok(_) => true,
+            Err(_) => false
+        });
+        
+        // Only one dispatcher can be registered
+        assert!(match setup_logging(log::LogLevelFilter::Debug, None) {
+            Ok(_) => false,
+            Err(_) => true
+        });
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,13 +21,32 @@ fn setup_logging(level: log::LogLevelFilter, file: Option<std::path::PathBuf>) -
         ))
     }).level(level);
 
-    let dispatcher = match file {
-        Some(path) => {
-            dispatcher.chain(fern::log_file(path)?)
+
+    let stderr_dispatcher = fern::Dispatch::new().filter(|data| {
+        match data.level().cmp(&log::LogLevelFilter::Warn.to_log_level().unwrap()) {
+            std::cmp::Ordering::Less => true,
+            std::cmp::Ordering::Equal => true,
+            _ => false
         }
-        None => dispatcher.chain(std::io::stdout())
+    }).chain(std::io::stderr());
+
+    let stdout_dispatcher = fern::Dispatch::new().filter(|data| {
+        match data.level().cmp(&log::LogLevelFilter::Warn.to_log_level().unwrap()) {
+            std::cmp::Ordering::Less => false,
+            std::cmp::Ordering::Equal => false,
+            _ => true
+        }
+    });
+
+
+    let stdout_dispatcher = match file {
+        Some(path) => {
+            stdout_dispatcher.chain(fern::log_file(path)?)
+        }
+        None => stdout_dispatcher.chain(std::io::stdout())
     };
 
+    let dispatcher = dispatcher.chain(stderr_dispatcher).chain(stdout_dispatcher);
     dispatcher.apply()?;
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,34 @@
+#[macro_use]
+extern crate log;
+extern crate fern;
+
 fn main() {
-    println!("Hello, world!");
+    let _ = setup_logging(log::LogLevelFilter::Debug, None);
+    debug!("Hey");
+    info!("Hey");
+    warn!("Hey");
+    error!("Hey");
+}
+
+fn setup_logging(level: log::LogLevelFilter, file: Option<std::path::PathBuf>) -> Result<(), fern::InitError> {
+    let dispatcher = fern::Dispatch::new().format(|out, message, record| {
+        out.finish(format_args!(
+            "[{}]\t[{}: {}]\t{}",
+            record.level(),
+            record.target(),
+            record.location().file(),
+            message
+        ))
+    }).level(level);
+
+    let dispatcher = match file {
+        Some(path) => {
+            dispatcher.chain(fern::log_file(path)?)
+        }
+        None => dispatcher.chain(std::io::stdout())
+    };
+
+    dispatcher.apply()?;
+
+    Ok(())
 }


### PR DESCRIPTION
Use stdout, stderr per default.
Log everything with a level >= "Warn" on stderr and everything else on "stdout".

`Fern` is used as the logging library.